### PR TITLE
Disable func-names for ES5

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -5,5 +5,6 @@ module.exports = {
     ].map(require.resolve),
     "rules": {
         "strict": [2, "function"],
+        "func-names": 0,
     },
 };


### PR DESCRIPTION
We are running into callbacks a lot in Angular (especially with Lodash callbacks), and this rule is increasing friction in development. Therefore, we are disabling the rule for ES5, since ES6 solves this issue by using arrow functions.

@VideoAmp/api @VideoAmp/front-end Hopefully no objections 😄 
