### PR TITLE
Enable object-shorthand

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ module.exports = {
             newIsCap: true,
             capIsNewExceptions: ["express.Router"],
         }],
-        "object-shorthand": ["error", "never"],
         "camelcase": ["off", { "properties": "always" }],
     },
 };


### PR DESCRIPTION
For some reason, the team decided to disable object-shorthand when we developed our styleguide. Since we have spent most of our time the past couple months in ES5 on Console, working more with API and default configuration showed that this is a useful feature that should stay defaulted to Airbnb's style.
