### PR TITLE
Remove unneeded deps and switch to base airbnb config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package extends Airbnb's styleguide with VideoAmp's code style, and provide
 
 ## Install
 ```sh
-npm install --save-dev eslint-config-videoamp eslint-config-airbnb eslint-config-airbnb-base eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-react eslint
+npm install --save-dev eslint-config-videoamp eslint-config-airbnb-base eslint-plugin-import eslint
 ```
 
 ## Usage
@@ -14,13 +14,13 @@ We export two ESLint configurations for our usage.
 
 ### eslint-config-videoamp
 
-Our default export contains all of Airbnb's ES6 lint rules with our custom configuration.
+Our default export contains all of Airbnb's base ES6 lint rules with our custom configuration.
 
 Add `"extends": "videoamp"` to your .eslintrc
 
 ### eslint-config-videoamp/es5
 
-Contains all of Airbnb's legacy (ES5 and below) lint rules with our custom configuration.
+Contains all of Airbnb's base legacy (ES5 and below) lint rules with our custom configuration.
 
 Add `"extends": "videoamp/es5"` to your .eslintrc
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     "extends": [
-        "eslint-config-airbnb",
+        "eslint-config-airbnb-base",
         "./base",
     ].map(require.resolve),
     "rules": {

--- a/package.json
+++ b/package.json
@@ -20,21 +20,13 @@
   },
   "homepage": "https://github.com/VideoAmp/eslint-config-videoamp#readme",
   "license": "UNLICENSED",
-  "dependencies": {
-    "eslint-config-airbnb": "~9.0.1",
-    "eslint-config-airbnb-base": "~3.0.1",
-    "eslint-plugin-import": "~1.8.1",
-    "eslint-plugin-jsx-a11y": "~1.4.2",
-    "eslint-plugin-react": "~5.1.1"
-  },
   "peerDependencies": {
-    "eslint-config-airbnb": "~9.0.1",
-    "eslint-config-airbnb-base": "~3.0.1",
-    "eslint-plugin-import": "~1.8.1",
-    "eslint-plugin-jsx-a11y": "~1.4.2",
-    "eslint-plugin-react": "~5.1.1"
+    "eslint-config-airbnb-base": "~5.0.3",
+    "eslint-plugin-import": "~1.14.0"
   },
   "devDependencies": {
-    "eslint": "~2.12.0"
+    "eslint": "~3.4.0",
+    "eslint-config-airbnb-base": "~5.0.3",
+    "eslint-plugin-import": "~1.14.0"
   }
 }


### PR DESCRIPTION
This PR removes a few dependencies, and opts to only use Airbnb's base JavaScript rules. This removes the need for the React dependencies.

Because this is a major update since it removes old dependencies, this will be a 2.0.0 bump for the package.

@davidungio 
