### PR TITLE
v4: Add shared plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,18 @@ npm install --save-dev eslint-config-videoamp eslint
 ```
 
 ## Usage
-If you would like to use the base rules, add `"extends": "videoamp"` to your `.eslintrc`.
+Add `"extends": "videoamp"` to your `.eslintrc`.
 
 ## Legacy `eslint-config-videoamp` for ES5 projects
 For projects that use ES5, see documentation from the `v2.1.0` config [here](https://github.com/VideoAmp/eslint-config-videoamp/blob/master/README.md#eslint-config-videoampes5).
 
 ## Resources
-See the [ESLint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information.
+- [ESLint config docs](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
+- [`eslint-plugin-import`](https://github.com/benmosher/eslint-plugin-import)
+- [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)
+- [`eslint-plugin-fp`](https://github.com/jfmengels/eslint-plugin-fp)
+- [`eslint-plugin-promise`](https://github.com/xjamundx/eslint-plugin-promise)
+- [`eslint-plugin-chai-expect`](https://github.com/turbo87/eslint-plugin-chai-expect)
 
 ## Contributing
-
 You can make sure this module lints with itself using `yarn lint`.

--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@ module.exports = {
         "./rules/es6",
         "./rules/plugins/import",
         "./rules/plugins/promise",
+        "./rules/plugins/fp",
     ].map(require.resolve),
 };

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
         "./rules/es6",
         "./rules/plugins/import",
         "./rules/plugins/promise",
+        "./rules/plugins/unicorn",
         "./rules/plugins/fp",
         "./rules/plugins/chai-expect",
     ].map(require.resolve),

--- a/index.js
+++ b/index.js
@@ -9,5 +9,6 @@ module.exports = {
         "./rules/plugins/import",
         "./rules/plugins/promise",
         "./rules/plugins/fp",
+        "./rules/plugins/chai-expect",
     ].map(require.resolve),
 };

--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
         "./rules/stylistic-issues",
         "./rules/es6",
         "./rules/plugins/import",
+        "./rules/plugins/promise",
     ].map(require.resolve),
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-promise": "^3.5.0",
     "eslint-restricted-globals": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^3.19.0"
   },
   "dependencies": {
+    "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-unicorn": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "javascript"
   ],
   "author": "VideoAmp <geeks@videoamp.com>",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/VideoAmp/eslint-config-videoamp/issues"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^3.19.0"
   },
   "dependencies": {
+    "eslint-plugin-chai-expect": "^1.1.1",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-promise": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-unicorn": "^2.1.1",
     "eslint-restricted-globals": "^0.1.1"
   }
 }

--- a/rules/plugins/chai-expect.js
+++ b/rules/plugins/chai-expect.js
@@ -1,0 +1,10 @@
+module.exports = {
+    "plugins": [
+        "chai-expect",
+    ],
+    "rules": {
+        "chai-expect/no-inner-compare": "error",
+        "chai-expect/missing-assertion": "error",
+        "chai-expect/terminating-properties": "error",
+    },
+};

--- a/rules/plugins/chai-expect.js
+++ b/rules/plugins/chai-expect.js
@@ -1,7 +1,5 @@
 module.exports = {
-    "plugins": [
-        "chai-expect",
-    ],
+    "plugins": ["chai-expect"],
     "rules": {
         "chai-expect/no-inner-compare": "error",
         "chai-expect/missing-assertion": "error",

--- a/rules/plugins/fp.js
+++ b/rules/plugins/fp.js
@@ -1,0 +1,27 @@
+module.exports = {
+    "env": {
+        "es6": true,
+    },
+    "plugins": [
+        "fp",
+    ],
+    "rules": {
+        "fp/no-arguments": "error",
+        "fp/no-class": "off",
+        "fp/no-delete": "error",
+        "fp/no-events": "error",
+        "fp/no-get-set": "error",
+        "fp/no-let": "off",
+        "fp/no-loops": "error",
+        "fp/no-mutating-assign": "error",
+        "fp/no-mutating-methods": "off",
+        "fp/no-mutation": "off",
+        "fp/no-nil": "off",
+        "fp/no-proxy": "error",
+        "fp/no-rest-parameters": "off",
+        "fp/no-this": "off",
+        "fp/no-throw": "off",
+        "fp/no-unused-expression": "error",
+        "fp/no-valueof-field": "error",
+    },
+};

--- a/rules/plugins/fp.js
+++ b/rules/plugins/fp.js
@@ -1,10 +1,8 @@
 module.exports = {
+    "plugins": ["fp"],
     "env": {
         "es6": true,
     },
-    "plugins": [
-        "fp",
-    ],
     "rules": {
         "fp/no-arguments": "error",
         "fp/no-class": "off",

--- a/rules/plugins/promise.js
+++ b/rules/plugins/promise.js
@@ -1,0 +1,16 @@
+module.exports = {
+    plugins: ["promise"],
+    rules: {
+        "promise/catch-or-return": "error",
+        "promise/no-return-wrap": "error",
+        "promise/param-names": "error",
+        "promise/always-return": "error",
+        "promise/no-native": "error",
+        "promise/no-nesting": "warn",
+        "promise/no-promise-in-callback": "warn",
+        "promise/no-callback-in-promise": "warn",
+        "promise/avoid-new": "warn",
+        "promise/prefer-await-to-then": "off",
+        "promise/prefer-await-to-callbacks": "off",
+    },
+};

--- a/rules/plugins/unicorn.js
+++ b/rules/plugins/unicorn.js
@@ -1,4 +1,5 @@
 module.exports = {
+    plugins: ["unicorn"],
     env: {
         es6: true,
     },

--- a/rules/plugins/unicorn.js
+++ b/rules/plugins/unicorn.js
@@ -1,0 +1,21 @@
+module.exports = {
+    env: {
+        es6: true,
+    },
+    rules: {
+        "unicorn/catch-error-name": "off",
+        "unicorn/explicit-length-check": "error",
+        "unicorn/filename-case": "off",
+        "unicorn/no-abusive-eslint-disable": "error",
+        "unicorn/no-process-exit": "off",
+        "unicorn/throw-new-error": "error",
+        "unicorn/number-literal-case": "error",
+        "unicorn/escape-case": "error",
+        "unicorn/no-array-instanceof": "error",
+        "unicorn/no-new-buffer": "off",
+        "unicorn/no-hex-escape": "error",
+        "unicorn/custom-error-definition": "error",
+        "unicorn/prefer-starts-ends-with": "error",
+        "unicorn/prefer-type-error": "error",
+    },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,16 @@ eslint-plugin-promise@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
 
+eslint-plugin-unicorn@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-2.1.1.tgz#3e9294366799b715e16a6df89159495b68930cb3"
+  dependencies:
+    lodash.camelcase "^4.1.1"
+    lodash.kebabcase "^4.0.1"
+    lodash.snakecase "^4.0.1"
+    lodash.upperfirst "^4.2.0"
+    req-all "^1.0.0"
+
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
@@ -644,9 +654,25 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.camelcase@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.kebabcase@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+
+lodash.snakecase@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+
+lodash.upperfirst@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
 
 lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
@@ -842,6 +868,10 @@ rechoir@^0.6.2:
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   dependencies:
     resolve "^1.1.6"
+
+req-all@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/req-all/-/req-all-1.0.0.tgz#d128569451c340b432409c656cf166260cd2628d"
 
 require-uncached@^1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,10 @@ eslint-plugin-import@^2.3.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
+eslint-plugin-promise@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
+
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,10 @@ eslint-module-utils@^2.0.0:
     debug "2.2.0"
     pkg-dir "^1.0.0"
 
+eslint-plugin-chai-expect@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-1.1.1.tgz#cd640b8b38cf6c3abcc378673b7b173b99ddc70a"
+
 eslint-plugin-fp@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-fp/-/eslint-plugin-fp-2.3.0.tgz#376d2a108710e981980bdc3875e3b9920da0489c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,6 +148,12 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+create-eslint-index@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/create-eslint-index/-/create-eslint-index-1.0.0.tgz#d954372d86d5792fcd67e9f2b791b1ab162411bb"
+  dependencies:
+    lodash.get "^4.3.0"
+
 d@^0.1.1, d@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
@@ -267,6 +273,12 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-ast-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-ast-utils/-/eslint-ast-utils-1.0.0.tgz#4acb86a0a018de08492f922a05b05928809472f4"
+  dependencies:
+    lodash.get "^4.4.2"
+
 eslint-import-resolver-node@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
@@ -281,6 +293,15 @@ eslint-module-utils@^2.0.0:
   dependencies:
     debug "2.2.0"
     pkg-dir "^1.0.0"
+
+eslint-plugin-fp@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fp/-/eslint-plugin-fp-2.3.0.tgz#376d2a108710e981980bdc3875e3b9920da0489c"
+  dependencies:
+    create-eslint-index "^1.0.0"
+    eslint-ast-utils "^1.0.0"
+    lodash "^4.13.1"
+    req-all "^0.1.0"
 
 eslint-plugin-import@^2.3.0:
   version "2.3.0"
@@ -662,6 +683,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.get@^4.3.0, lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.kebabcase@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
@@ -674,7 +699,7 @@ lodash.upperfirst@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
 
-lodash@^4.0.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -868,6 +893,10 @@ rechoir@^0.6.2:
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   dependencies:
     resolve "^1.1.6"
+
+req-all@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"
 
 req-all@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This release adds ESLint plugins with rules shared across our projects. 

Detailed changes below:
- Update license info in `package.json`
- Add [`eslint-plugin-promise`](https://github.com/xjamundx/eslint-plugin-promise)
- Add [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn)
- Add [`eslint-plugin-fp`](https://github.com/jfmengels/eslint-plugin-fp)
- Add [`eslint-plugin-chai-expect`](https://github.com/turbo87/eslint-plugin-chai-expect)