### PR TITLE
Disable no-unused-expression rule

### DIFF
--- a/rules/plugins/fp.js
+++ b/rules/plugins/fp.js
@@ -19,7 +19,7 @@ module.exports = {
         "fp/no-rest-parameters": "off",
         "fp/no-this": "off",
         "fp/no-throw": "off",
-        "fp/no-unused-expression": "error",
+        "fp/no-unused-expression": "off",
         "fp/no-valueof-field": "error",
     },
 };


### PR DESCRIPTION
This rule was breaking tests since they are technically unused expressions. This rule in general isn't very useful, so we decided to disable it.