### PR TITLE
Disable camelcase rule

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -11,7 +11,7 @@ module.exports = {
         "brace-style": ["error", "1tbs", { allowSingleLine: true }],
 
         // require camel case names
-        "camelcase": ["error", { properties: "always" }],
+        "camelcase": ["off", { "properties": "always" }],
 
         // enforce or disallow capitalization of the first letter of a comment
         // http://eslint.org/docs/rules/capitalized-comments


### PR DESCRIPTION
This rule is a regression from `3.0.0`, and needs to be restored for our Node projects. This is going into the shared configuration because it also affects React projects consuming non-cameled JSON bodies.