### PR TITLE
chore(ramda): Update underscore dangle for ramda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Jetbrains
+.idea/

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -292,7 +292,7 @@ module.exports = {
         "no-trailing-spaces": "error",
 
         // disallow dangling underscores in identifiers
-        "no-underscore-dangle": ["error"],
+        "no-underscore-dangle": ["error", { allow: ["__"] }],
 
         // disallow the use of Boolean literals in conditional expressions
         // also, prefer `a || b` over `a ? a : b`

--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -292,7 +292,7 @@ module.exports = {
         "no-trailing-spaces": "error",
 
         // disallow dangling underscores in identifiers
-        "no-underscore-dangle": ["error", { allowAfterThis: false }],
+        "no-underscore-dangle": ["error"],
 
         // disallow the use of Boolean literals in conditional expressions
         // also, prefer `a || b` over `a ? a : b`


### PR DESCRIPTION
Intent:
- Ramda has a special function called `R.__` that is tripping our `no-underscore-dangle` rule; allow this case to pass.

Changes:
- Remove `{ allowAfterThis: false }` because that is already the default setting
- Add exception for `__` to allow `R.__` to pass

Notes;
- Exceptions are placed on the identifier itself, so the rule is for `__` and not specifically `R.__` -- I did not find an effective way to only allow `R.__`